### PR TITLE
Delete session on client delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ client = OpaClient() # default host='localhost', port=8181, version='v1'
 
 client.check_connection() # response is  Yes I'm here :)
 
+# Ensure the connection is closed correctly by deleting the client
+del client
 ```
 
 
@@ -76,6 +78,7 @@ client = OpaClient(
 
 client.check_connection() # response is  Yes I'm here :)
 
+del client
 ```
 
 
@@ -92,6 +95,7 @@ client.update_opa_policy_fromfile("/your/path/filename.rego", endpoint="fromfile
 
 client.get_policies_list() # response is ["fromfile"]
 
+del client
 ```
 
 
@@ -108,6 +112,7 @@ client.update_opa_policy_fromurl("http://opapolicyurlexample.test/example.rego",
 
 client.get_policies_list() # response is ["fromfile","fromurl"]
 
+del client
 ```
 
 
@@ -125,6 +130,7 @@ client.delete_opa_policy("fromfile") # response is True
 
 client.get_policies_list() # response is [fromurl"]
 
+del client
 ```
 
 ### Get raw data from OPA service ###
@@ -139,6 +145,7 @@ client = OpaClient() # default host='localhost', port=8181, version='v1'
 
 print(client.get_opa_raw_data("testapi/testdata"))  # response is {'result': ['world', 'hello']}
 
+del client
 ```
 
 ### Save policy to file from OPA service ###
@@ -153,7 +160,7 @@ client = OpaClient() # default host='localhost', port=8181, version='v1'
 
 client.opa_policy_to_file(policy_name="fromurl",path="/your/path",filename="example.rego")  # response is True
 
-
+del client
 ```
 
 ### Delete data from OPA service ###
@@ -168,7 +175,7 @@ client = OpaClient() # default host='localhost', port=8181, version='v1'
 
 client.delete_opa_data("testapi")  # response is True
 
-
+del client
 ```
 
 
@@ -186,6 +193,7 @@ client.get_policies_info()
 
 # response is {'testpolicy': {'path': ['http://your-opa-service/v1/data/play'], 'rules': ['http://your-opa-service/v1/data/play/hello']}
 
+del client
 ```
 
 
@@ -204,6 +212,7 @@ client.check_permission(input_data=permission_you_want_check, policy_name="testp
 
 # response is {'result': True}
 
+del client
 ```
 
 

--- a/opa_client/opa.py
+++ b/opa_client/opa.py
@@ -131,6 +131,9 @@ class OpaClient:
             )
             self.__session = https.request
 
+    def __del__(self):
+        del self.__session
+        
     def check_connection(self):
         """
             Checks whether established connection config True or not.   


### PR DESCRIPTION
The session pool isn't being properly closed at the moment, which can lead to errors like

```
ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 47862), raddr=('127.0.0.1', 8181)>
```

This PR adds a `__del__` function to the client class to ensure the session pool is closed properly on instance deletion by deleting the session.