### PR TITLE
Fix __del__

### DIFF
--- a/opa_client/opa.py
+++ b/opa_client/opa.py
@@ -118,22 +118,22 @@ class OpaClient:
             self.__headers.update({"User-Agent": generate_user_agent()})
 
         if self.__secure:
-            https = urllib3.PoolManager(
+            self.__manager = urllib3.PoolManager(
                 cert_reqs="CERT_REQUIRED",
                 assert_hostname=False,
                 ca_certs=self.__cert,
                 headers=self.__headers,
             )
-            self.__session = https.request
+            self.__session = self.__manager.request
         else:
-            https = urllib3.PoolManager(
+            self.__manager = urllib3.PoolManager(
                 headers=self.__headers
             )
-            self.__session = https.request
+            self.__session = self.__manager.request
 
     def __del__(self):
-        del self.__session
-        
+        del self.__manager
+
     def check_connection(self):
         """
             Checks whether established connection config True or not.   

--- a/opa_client/opa.py
+++ b/opa_client/opa.py
@@ -132,7 +132,13 @@ class OpaClient:
             self.__session = self.__manager.request
 
     def __del__(self):
-        del self.__manager
+        self.close_connection()
+
+    def close_connection(self):
+        """
+        Close all currently open connections to the OPA server
+        """
+        self.__manager.clear()
 
     def check_connection(self):
         """

--- a/opa_client/test/test_opa.py
+++ b/opa_client/test/test_opa.py
@@ -21,7 +21,8 @@ class TestClient(TestCase):
 
     def tearDown(self):
         '''her bir testden sonra run olur'''
-        pass
+        """ Close the connection to the OPA server by deleting the client"""
+        del self.myclient
 
     def test_client(self):
 


### PR DESCRIPTION
Apologies. I messed up the last PR - didn't properly test it was working. Have now fixed it using a better method

- added a `close_connection` function to close the connections without deleting the client
- storing the PoolManager instance as needed to clear the connections
- added the del to the tests teardown