### PR TITLE
Return complete data object instead of message

### DIFF
--- a/opa_client/opa.py
+++ b/opa_client/opa.py
@@ -413,8 +413,8 @@ class OpaClient:
                 return True
 
             raise RegoParseError(
-                json.loads(response.data.decode()).get("code"),
-                json.loads(response.data.decode()).get("message"),
+                response.status,
+                json.loads(response.data.decode())
             )
 
         return False


### PR DESCRIPTION
While raising RegoParseError, response.data object contains some more information like error location and its details in it. Which is useful to identify the exact error and line number in Rego file.