### PR TITLE
Use context manager instead of finalizer to free resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Open Policy Agent (OPA) Client 
+# Python Open Policy Agent (OPA) Client
 
 [![MIT licensed](https://img.shields.io/github/license/Turall/OPA-python-client)](https://raw.githubusercontent.com/Turall/OPA-python-client/master/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/Turall/OPA-python-client.svg)](https://github.com/Turall/OPA-python-client/stargazers)
@@ -23,9 +23,7 @@ $ poetry shell
 $ poetry add OPA-python-client
 ```
 
-
-
-## Usage Examples 
+## Usage Examples
 
 ```python
 >>> from opa_client.opa import OpaClient
@@ -34,11 +32,11 @@ $ poetry add OPA-python-client
 'Yes I"m here :)'
 >>>  test_policy = """
 ...     package play
-... 
+...
 ...     import data.testapi.testdata
-... 
+...
 ...     default hello = false
-... 
+...
 ...     hello {
 ...         m := input.message
 ...         testdata[i] == m
@@ -57,20 +55,14 @@ True
 {'result': True}
 ```
 
-
 ### Connection to OPA service
 
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() # default host='localhost', port=8181, version='v1'
-
-client.check_connection() # response is  Yes I'm here :)
-
-# Ensure the connection is closed correctly by deleting the client
-del client
+with OpaClient() as client: # default host='localhost', port=8181, version='v1'
+    client.check_connection() # response is  Yes I'm here :)
 ```
-
 
 ### Connection to OPA service with SSL
 
@@ -78,161 +70,124 @@ del client
 from opa_client.opa import OpaClient
 
 
-client = OpaClient(
+with OpaClient(
     host="https://192.168.99.100",
     port=8181,
     version="v1",
     ssl=True,
     cert="/your/certificate/file/path/mycert.crt",
-)
-
-client.check_connection() # response is  Yes I'm here :)
-
-del client
+) as client:
+    client.check_connection() # response is  Yes I'm here :)
 ```
-
 
 ### Update policy from rego file
 
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-client.update_opa_policy_fromfile("/your/path/filename.rego", endpoint="fromfile") # response is True
-
-client.get_policies_list() # response is ["fromfile"]
-
-del client
+with OpaClient() as client:
+    client.update_opa_policy_fromfile("/your/path/filename.rego", endpoint="fromfile") # response is True
+    client.get_policies_list() # response is ["fromfile"]
 ```
-
 
 ### Update policy from URL
 
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-
-client.update_opa_policy_fromurl("http://opapolicyurlexample.test/example.rego", endpoint="fromurl") # response is True
-
-client.get_policies_list() # response is ["fromfile","fromurl"]
-
-del client
+with OpaClient() as client:
+    client.update_opa_policy_fromurl("http://opapolicyurlexample.test/example.rego", endpoint="fromurl") # response is True
+    client.get_policies_list() # response is ["fromfile","fromurl"]
 ```
 
-
 ### Delete policy
-
 
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-client.delete_opa_policy("fromfile") # response is True
-
+with OpaClient() as client:
+    client.delete_opa_policy("fromfile") # response is True
+    client.get_policies_list() # response is []
 client.get_policies_list() # response is [] 
-
-del client
+    client.get_policies_list() # response is []
 ```
 
 ### Get raw data from OPA service
 
-
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
+with OpaClient() as client:
+    print(client.get_opa_raw_data("testapi/testdata"))  # response is {'result': ['world', 'hello']}
 
-print(client.get_opa_raw_data("testapi/testdata"))  # response is {'result': ['world', 'hello']}
-
-# You can use query params for additional info
-# provenance - If parameter is true, response will include build/version info in addition to the result.
+    # You can use query params for additional info
+    # provenance - If parameter is true, response will include build/version info in addition to the result.
+    # metrics - Return query performance metrics in addition to result
 # metrics - Return query performance metrics in addition to result 
+    # metrics - Return query performance metrics in addition to result
 
+    print(client.get_opa_raw_data("userinfo",query_params={"provenance": True}))
 print(client.get_opa_raw_data("userinfo",query_params={"provenance": True})) 
-# response is {'provenance': {'version': '0.25.2', 'build_commit': '4c6e524', 'build_timestamp': '2020-12-08T16:56:55Z', 'build_hostname': '3bb58334a5a9'}, 'result': {'user_roles': {'alice': ['admin'], 'bob': ['employee', 'billing'], 'eve': ['customer']}}}
+    print(client.get_opa_raw_data("userinfo",query_params={"provenance": True}))
+    # response is {'provenance': {'version': '0.25.2', 'build_commit': '4c6e524', 'build_timestamp': '2020-12-08T16:56:55Z', 'build_hostname': '3bb58334a5a9'}, 'result': {'user_roles': {'alice': ['admin'], 'bob': ['employee', 'billing'], 'eve': ['customer']}}}
 
+    print(client.get_opa_raw_data("userinfo",query_params={"metrics": True}))
 print(client.get_opa_raw_data("userinfo",query_params={"metrics": True})) 
+    print(client.get_opa_raw_data("userinfo",query_params={"metrics": True}))
 
-# response is {'metrics': {'counter_server_query_cache_hit': 0, 'timer_rego_external_resolve_ns': 231, 'timer_rego_input_parse_ns': 381, 'timer_rego_query_compile_ns': 40173, 'timer_rego_query_eval_ns': 12674, 'timer_rego_query_parse_ns': 5692, 'timer_server_handler_ns': 83490}, 'result': {'user_roles': {'alice': ['admin'], 'bob': ['employee', 'billing'], 'eve': ['customer']}}}
-
-del client
+    # response is {'metrics': {'counter_server_query_cache_hit': 0, 'timer_rego_external_resolve_ns': 231, 'timer_rego_input_parse_ns': 381, 'timer_rego_query_compile_ns': 40173, 'timer_rego_query_eval_ns': 12674, 'timer_rego_query_parse_ns': 5692, 'timer_server_handler_ns': 83490}, 'result': {'user_roles': {'alice': ['admin'], 'bob': ['employee', 'billing'], 'eve': ['customer']}}}
 ```
-
 
 ### Save policy to file from OPA service
 
-
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-client.opa_policy_to_file(policy_name="fromurl",path="/your/path",filename="example.rego")  # response is True
-
-del client
+with OpaClient() as client:
+    client.opa_policy_to_file(policy_name="fromurl",path="/your/path",filename="example.rego")  # response is True
 ```
-
 
 ### Delete data from OPA service
 
-
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-client.delete_opa_data("testapi")  # response is True
-
-del client
+with OpaClient() as client:
+    client.delete_opa_data("testapi")  # response is True
 ```
-
 
 ### Information about policy path and rules
 
-
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
-client.get_policies_info()
+with OpaClient() as client:
+    client.get_policies_info()
 
 # response is {'testpolicy': {'path': ['http://your-opa-service/v1/data/play'], 'rules': ['http://your-opa-service/v1/data/play/hello']}
-
-del client
 ```
-
 
 ### Check permissions
 
-
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient() 
-
 permission_you_want_check = {"input": {"message": "hello"}}
-client.check_permission(input_data=permission_you_want_check, policy_name="testpolicy", rule_name="hello")
+
+with OpaClient() as client:
+    client.check_permission(input_data=permission_you_want_check, policy_name="testpolicy", rule_name="hello")
 
 # response is {'result': True}
 
 # You can use query params for additional info
 # provenance - If parameter is true, response will include build/version info in addition to the result.
-# metrics - Return query performance metrics in addition to result 
-
-del client
+# metrics - Return query performance metrics in addition to result
 ```
 
 ### Queries a package rule with the given input data
 
 ```python
 from opa_client.opa import OpaClient
-
-client = OpaClient()
 
 rego = """
 package play
@@ -246,17 +201,15 @@ hello {
 """
 
 check_data = {"message": "world"}
-client.check_policy_rule(input_data=check_data, package_path="play", rule_name="hello") # response {'result': True}
+
+with OpaClient() as client:
+    client.check_policy_rule(input_data=check_data, package_path="play", rule_name="hello") # response {'result': True}
 ```
 
 ### Execute an Ad-hoc Query
 
 ```python
 from opa_client.opa import OpaClient
-
-client = OpaClient()
-
-print(client.ad_hoc_query(query_params={"q": "data.userinfo.user_roles[name]"})) # response is {}
 
 data = {
     "user_roles": {
@@ -273,15 +226,18 @@ data = {
     }
 }
 
-print(client.update_or_create_opa_data(data, "userinfo")) # response is True
+with OpaClient() as client:
+    print(client.ad_hoc_query(query_params={"q": "data.userinfo.user_roles[name]"})) # response is {}
 
-# execute query 
-print(client.ad_hoc_query(query_params={"q": "data.userinfo.user_roles[name]"})) 
-# response is {'result': [{'name': 'eve'}, {'name': 'alice'}, {'name': 'bob'}]}
+    print(client.update_or_create_opa_data(data, "userinfo")) # response is True
 
-#you can send body request
-print(client.ad_hoc_query(body={"query": "data.userinfo.user_roles[name] "})) 
-# response is {'result': [{'name': 'eve'}, {'name': 'alice'}, {'name': 'bob'}]}
+    # execute query
+    print(client.ad_hoc_query(query_params={"q": "data.userinfo.user_roles[name]"}))
+    # response is {'result': [{'name': 'eve'}, {'name': 'alice'}, {'name': 'bob'}]}
+
+    #you can send body request
+    print(client.ad_hoc_query(body={"query": "data.userinfo.user_roles[name] "}))
+    # response is {'result': [{'name': 'eve'}, {'name': 'alice'}, {'name': 'bob'}]}
 ```
 
 ### Check OPA healthy. If you want check bundels or plugins, add query params for this.
@@ -289,15 +245,13 @@ print(client.ad_hoc_query(body={"query": "data.userinfo.user_roles[name] "}))
 ```python
 from opa_client.opa import OpaClient
 
-client = OpaClient()
-
-print(client.check_health()) # response is  True or False
-print(client.check_health({"bundle": True})) # response is  True or False
-# If your diagnostic url different than default url, you can provide it.
-print(client.check_health(diagnostic_url="http://localhost:8282/health"))  # response is  True or False
-print(client.check_health(query={"bundle": True}, diagnostic_url="http://localhost:8282/health"))  # response is  True or False
+with OpaClient() as client:
+    print(client.check_health()) # response is  True or False
+    print(client.check_health({"bundle": True})) # response is  True or False
+    # If your diagnostic url different than default url, you can provide it.
+    print(client.check_health(diagnostic_url="http://localhost:8282/health"))  # response is  True or False
+    print(client.check_health(query={"bundle": True}, diagnostic_url="http://localhost:8282/health"))  # response is  True or False
 ```
-
 
 # Contributing
 

--- a/opa_client/opa.py
+++ b/opa_client/opa.py
@@ -88,7 +88,9 @@ class OpaClient:
 
         if host.startswith('https://'):
             self.__host = host
-            self.__root_url = '{}:{}/{}'.format(self.__host, self.__port, self.__version)
+            self.__root_url = '{}:{}/{}'.format(
+                self.__host, self.__port, self.__version
+            )
 
         elif host.startswith('http://'):
             self.__host = host
@@ -98,7 +100,9 @@ class OpaClient:
                     'With ssl enabled not possible to have connection with http',
                 )
 
-            self.__root_url = '{}:{}/{}'.format(self.__host, self.__port, self.__version)
+            self.__root_url = '{}:{}/{}'.format(
+                self.__host, self.__port, self.__version
+            )
 
         else:
             self.__host = host
@@ -127,6 +131,12 @@ class OpaClient:
             self.__manager = urllib3.PoolManager(headers=self.__headers)
             self.__session = self.__manager.request
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.close_connection()
+
     def __del__(self):
         self.close_connection()
 
@@ -147,7 +157,9 @@ class OpaClient:
 
         url = self.__policy_root.format(self.__root_url, '')
         try:
-            response = self.__session('GET', url, retries=self.retries, timeout=self.timeout)
+            response = self.__session(
+                'GET', url, retries=self.retries, timeout=self.timeout
+            )
             if response.status == 200:
                 return "Yes I'm here :)"
 
@@ -156,7 +168,9 @@ class OpaClient:
 
         raise ConnectionsError('service unreachable', 'check config and try again')
 
-    def check_health(self, query: Dict[str, bool] = None, diagnostic_url: str = None) -> bool:
+    def check_health(
+        self, query: Dict[str, bool] = None, diagnostic_url: str = None
+    ) -> bool:
         """
         Check OPA healthy. If you want check bundels or plugins, add query params for this.
         If your diagnostic url different than default url, you can provide it.
@@ -178,7 +192,9 @@ class OpaClient:
             url = '{}{}:{}/{}'.format(self.__schema, self.__host, self.__port, 'health')
         if query:
             url = self.prepare_args(url, query)
-        response = self.__session('GET', url, retries=self.retries, timeout=self.timeout)
+        response = self.__session(
+            'GET', url, retries=self.retries, timeout=self.timeout
+        )
         if response.status == 200:
             return True
         return False
@@ -248,7 +264,9 @@ class OpaClient:
 
         return self.__update_opa_data(new_data, endpoint)
 
-    def get_opa_raw_data(self, data_name: str = '', query_params: Dict[str, bool] = dict()) -> dict:
+    def get_opa_raw_data(
+        self, data_name: str = '', query_params: Dict[str, bool] = dict()
+    ) -> dict:
         """Returns OPA raw data in string type
         ```
         param :: data_name : OPA data name you want get
@@ -258,7 +276,10 @@ class OpaClient:
         return self.__get_opa_raw_data(data_name, query_params)
 
     def opa_policy_to_file(
-        self, policy_name: str, path: Union[str, None] = None, filename: str = 'opa_policy.rego'
+        self,
+        policy_name: str,
+        path: Union[str, None] = None,
+        filename: str = 'opa_policy.rego',
     ):
         """Write OPA service policy to the  file.
         ```
@@ -313,14 +334,18 @@ class OpaClient:
 
         return self.__check(input_data, policy_name, rule_name, query_params)
 
-    def check_policy_rule(self, input_data: dict, package_path: str, rule_name: str = None) -> dict:
+    def check_policy_rule(
+        self, input_data: dict, package_path: str, rule_name: str = None
+    ) -> dict:
         """
         Queries a package rule with the given input data
         """
 
         return self.__query(input_data, package_path, rule_name)
 
-    def ad_hoc_query(self, *, query_params: Dict[str, str] = None, body: Dict[str, str] = None):
+    def ad_hoc_query(
+        self, *, query_params: Dict[str, str] = None, body: Dict[str, str] = None
+    ):
         """Execute an ad-hoc query and return bindings for variables found in the query.
         ```
         param :: query_params for sending query string in url
@@ -328,7 +353,9 @@ class OpaClient:
         ```
         """
 
-        url = '{}{}:{}/{}/{}'.format(self.__schema, self.__host, self.__port, 'v1', 'query')
+        url = '{}{}:{}/{}/{}'.format(
+            self.__schema, self.__host, self.__port, 'v1', 'query'
+        )
         if body:
             encoded_json = json.dumps(body).encode('utf-8')
             response = self.__session(
@@ -340,7 +367,9 @@ class OpaClient:
             )
         elif query_params:
             url = self.prepare_args(url, query_params)
-            response = self.__session('GET', url, retries=self.retries, timeout=self.timeout)
+            response = self.__session(
+                'GET', url, retries=self.retries, timeout=self.timeout
+            )
         data = json.loads(response.data.decode('utf-8'))
         if response.status == 200:
             return data
@@ -356,7 +385,9 @@ class OpaClient:
     def __get_opa_raw_data(self, data_name: str, query_params: Dict[str, bool]):
         url = self.__data_root.format(self.__root_url, data_name)
         url = self.prepare_args(url, query_params)
-        response = self.__session('GET', url, retries=self.retries, timeout=self.timeout)
+        response = self.__session(
+            'GET', url, retries=self.retries, timeout=self.timeout
+        )
         code = response.status
         response = json.loads(response.data.decode('utf-8'))
         return response if code == 200 else (code, 'not found')
@@ -410,7 +441,9 @@ class OpaClient:
     def __get_opa_policy(self, policy_name: str) -> dict:
         url = self.__policy_root.format(self.__root_url, policy_name)
 
-        response = self.__session('GET', url, retries=self.retries, timeout=self.timeout)
+        response = self.__session(
+            'GET', url, retries=self.retries, timeout=self.timeout
+        )
         data = json.loads(response.data.decode('utf-8'))
         if response.status == 200:
 
@@ -422,7 +455,9 @@ class OpaClient:
         response = requests.get(url, headers=self.__headers)
         return self.__update_opa_policy_fromstring(response.text, endpoint)
 
-    def __opa_policy_to_file(self, policy_name: str, path: Union[str, None], filename: str) -> bool:
+    def __opa_policy_to_file(
+        self, policy_name: str, path: Union[str, None], filename: str
+    ) -> bool:
         raw_policy = self.__get_opa_policy(policy_name)
         if isinstance(raw_policy, dict):
             try:
@@ -440,7 +475,9 @@ class OpaClient:
     def __delete_opa_policy(self, policy_name: str) -> bool:
         url = self.__policy_root.format(self.__root_url, policy_name)
 
-        response = self.__session('DELETE', url, retries=self.retries, timeout=self.timeout)
+        response = self.__session(
+            'DELETE', url, retries=self.retries, timeout=self.timeout
+        )
         data = json.loads(response.data.decode('utf-8'))
         if response.status == 200:
             return True
@@ -451,7 +488,11 @@ class OpaClient:
         url = self.__policy_root.format(self.__root_url, '')
         temp = []
         response = self.__session(
-            'GET', url, retries=self.retries, timeout=self.timeout, headers=self.__headers
+            'GET',
+            url,
+            retries=self.retries,
+            timeout=self.timeout,
+            headers=self.__headers,
         )
 
         response = json.loads(response.data.decode())
@@ -465,7 +506,9 @@ class OpaClient:
     def __delete_opa_data(self, data_name: str) -> bool:
         url = self.__data_root.format(self.__root_url, data_name)
 
-        response = self.__session('DELETE', url, retries=self.retries, timeout=self.timeout)
+        response = self.__session(
+            'DELETE', url, retries=self.retries, timeout=self.timeout
+        )
         if response.data:
             data = json.loads(response.data.decode('utf-8'))
         if response.status == 204:
@@ -476,7 +519,11 @@ class OpaClient:
     def __get_policies_info(self) -> dict:
         url = self.__policy_root.format(self.__root_url, '')
         policy = self.__session(
-            'GET', url, retries=self.retries, timeout=self.timeout, headers=self.__headers
+            'GET',
+            url,
+            retries=self.retries,
+            timeout=self.timeout,
+            headers=self.__headers,
         )
 
         policy = json.loads(policy.data.decode())
@@ -502,12 +549,20 @@ class OpaClient:
         return temp_dict
 
     def __check(
-        self, input_data: dict, policy_name: str, rule_name: str, query_params: Dict[str, bool]
+        self,
+        input_data: dict,
+        policy_name: str,
+        rule_name: str,
+        query_params: Dict[str, bool],
     ) -> dict:
         url = self.__policy_root.format(self.__root_url, policy_name)
 
         policy = self.__session(
-            'GET', url, headers=self.__headers, retries=self.retries, timeout=self.timeout
+            'GET',
+            url,
+            headers=self.__headers,
+            retries=self.retries,
+            timeout=self.timeout,
         )
         policy = json.loads(policy.data.decode('utf-8'))
         result = policy.get('result')
@@ -538,9 +593,13 @@ class OpaClient:
                 data = json.loads(response.data.decode('utf-8'))
                 return data
 
-        raise CheckPermissionError(f'{rule_name} rule not found', 'policy or rule name not correct')
+        raise CheckPermissionError(
+            f'{rule_name} rule not found', 'policy or rule name not correct'
+        )
 
-    def __query(self, input_data: dict, package_path: str, rule_name: str = None) -> dict:
+    def __query(
+        self, input_data: dict, package_path: str, rule_name: str = None
+    ) -> dict:
         if '.' in package_path:
             package_path = package_path.replace('.', '/')
         if rule_name:
@@ -555,7 +614,9 @@ class OpaClient:
             data = json.loads(response.data.decode('utf-8'))
             return data
 
-        raise CheckPermissionError(f'{rule_name} rule not found', 'policy or rule name not correct')
+        raise CheckPermissionError(
+            f'{rule_name} rule not found', 'policy or rule name not correct'
+        )
 
     @property
     def _host(self):

--- a/opa_client/test/test_opa.py
+++ b/opa_client/test/test_opa.py
@@ -11,83 +11,74 @@ from opa_client.opa import OpaClient
 
 
 class TestClient(TestCase):
-    def setUp(self):
-        """Set up the test  for OpaClient object"""
-
-        self.myclient = OpaClient()
-
-    def tearDown(self):
-        """Close the connection to the OPA server by deleting the client"""
-        del self.myclient
-
     def test_client(self):
         """Set up the test  for OpaClient object"""
-
-        client = OpaClient('localhost', 8181, 'v1')
-        self.assertEqual('http://localhost:8181/v1', client._root_url)
-
-        client = OpaClient('localhost', 8181, 'v1')
-        self.assertEqual('http://localhost:8181/v1', client._root_url)
-
-        self.assertFalse(False, self.myclient._secure)
-        self.assertEqual('http://', self.myclient._schema)
-        self.assertEqual('v1', self.myclient._version)
-        self.assertEqual('localhost', self.myclient._host)
-        self.assertEqual(8181, self.myclient._port)
+        with OpaClient() as client:
+            self.assertEqual('http://localhost:8181/v1', client._root_url)
+            self.assertFalse(False, client._secure)
+            self.assertEqual('http://', client._schema)
+            self.assertEqual('v1', client._version)
+            self.assertEqual('localhost', client._host)
+            self.assertEqual(8181, client._port)
 
     def test_functions(self):
+        with OpaClient() as client:
+            self.assertEqual("Yes I'm here :)", client.check_connection())
+            self.assertEqual(list(), client.get_policies_list())
+            self.assertEqual(dict(), client.get_policies_info())
 
-        self.assertEqual("Yes I'm here :)", self.myclient.check_connection())
-        self.assertEqual(list(), self.myclient.get_policies_list())
+            new_policy = """
+                package play
 
-        self.assertEqual(dict(), self.myclient.get_policies_info())
+                default hello = false
 
-        # _dict = {'test': {'path': [
-        #     'http://localhost:8181/v1/data/play'],
-        #       'rules': ['http://localhost:8181/v1/data/play/hello']}
-        # }
+                hello {
+                    m := input.message
+                    m == "world"
+                }
+            """
+            self.assertEqual(
+                True, client.update_opa_policy_fromstring(new_policy, 'test')
+            )
 
-        # self.assertEqual(_dict, self.myclient.get_policies_info())
-
-        new_policy = """
-            package play
-
-            default hello = false
-
-            hello {
-                m := input.message
-                m == "world"
+            self.assertEqual(['test'], client.get_policies_list())
+            _dict = {
+                'test': {
+                    'path': ['http://localhost:8181/v1/data/play'],
+                    'rules': ['http://localhost:8181/v1/data/play/hello'],
+                }
             }
-        """
-        self.assertEqual(True, self.myclient.update_opa_policy_fromstring(new_policy, 'test'))
 
-        self.assertEqual(['test'], self.myclient.get_policies_list())
-        _dict = {
-            'test': {
-                'path': ['http://localhost:8181/v1/data/play'],
-                'rules': ['http://localhost:8181/v1/data/play/hello'],
-            }
-        }
+            self.assertEqual(_dict, client.get_policies_info())
 
-        self.assertEqual(_dict, self.myclient.get_policies_info())
+            my_policy_list = [
+                {
+                    'resource': '/api/someapi',
+                    'identity': 'your_identity',
+                    'method': 'PUT',
+                },
+                {
+                    'resource': '/api/someapi',
+                    'identity': 'your_identity',
+                    'method': 'GET',
+                },
+            ]
 
-        my_policy_list = [
-            {'resource': '/api/someapi', 'identity': 'your_identity', 'method': 'PUT'},
-            {'resource': '/api/someapi', 'identity': 'your_identity', 'method': 'GET'},
-        ]
+            self.assertTrue(
+                True,
+                client.update_or_create_opa_data(
+                    my_policy_list, 'exampledata/accesses'
+                ),
+            )
+            value = {'result': {'hello': False}}
 
-        self.assertTrue(
-            True, self.myclient.update_or_create_opa_data(my_policy_list, 'exampledata/accesses')
-        )
-        value = {'result': {'hello': False}}
+            self.assertEqual(True, client.opa_policy_to_file('test'))
 
-        self.assertEqual(True, self.myclient.opa_policy_to_file('test'))
+            self.assertEqual(value, client.get_opa_raw_data('play'))
 
-        self.assertEqual(value, self.myclient.get_opa_raw_data('play'))
+            self.assertTrue(True, client.delete_opa_policy('test'))
+            with self.assertRaises(DeletePolicyError):
+                client.delete_opa_policy('test')
 
-        self.assertTrue(True, self.myclient.delete_opa_policy('test'))
-        with self.assertRaises(DeletePolicyError):
-            self.myclient.delete_opa_policy('test')
-
-        with self.assertRaises(DeleteDataError):
-            self.myclient.delete_opa_data('play')
+            with self.assertRaises(DeleteDataError):
+                client.delete_opa_data('play')


### PR DESCRIPTION
It is better to use the context manager to free resources, because
the `__del__()` method might not be called for objects that exists
when the interpreter exits. The `del` also does not directly call
the `__del__()` method, it just decreases the reference counter.

Another advantage is that one does not need to remember to free the
resources, they are freed automaticaly when object exits the `with`
block.

<https://docs.python.org/3/reference/datamodel.html#object.__del__>

---

Maybe it would be beneficial to remove the `__del__` method. However, 
that is a breaking change. If you do not mind bumping the version I can add 
it to the PR as well.

My editor autoformated the code with black, I may revert the formatting 
changes if you like.

